### PR TITLE
chore: convert to ESM

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,5 +6,5 @@
 - [ ] Add unit tests
 - [ ] Add completion command
 - [x] Configure linter - 'dont warn for Node globals like console'
-- [ ] Swith to ESM and import latest versions of dependencies
+- [x] Swith to ESM and import latest versions of dependencies
 - [ ] Add README

--- a/cli.js
+++ b/cli.js
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 
-const fetch = require('node-fetch');
-const yargs = require('yargs');
-const copyPaste = require('copy-paste');
+import fetch from "node-fetch";
+import yargs from "yargs";
+import copyPaste  from "copy-paste";
 
 const apiUrl = 'https://baconipsum.com/api/';
 
 // Define command-line options using yargs
-const argv = yargs
+const argv = yargs(process.argv.slice(2))
   .scriptName('bacon')
   .option('type', {
     alias: 't',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,7 @@ import jestPlugin from "eslint-plugin-jest";
 export default [
   {
     files: ["**/*.js"],
-    languageOptions: { sourceType: "commonjs", globals: globals.nodeBuiltin}
+    languageOptions: { sourceType: "module", ecmaVersion: "latest", globals: globals.nodeBuiltin}
   },
   { languageOptions: { ...jestPlugin.environments.globals } },
   pluginJs.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@beauraines/bacon-ipsum-cli",
   "version": "0.1.3",
   "description": "CLI for Bacon Ipsum text",
-  "main": "cli.js",
+  "exports": "./cli.js",
+  "type": "module",
   "bin": {
     "bacon-ipsum": "cli.js"
   },


### PR DESCRIPTION
Converts from CommonJS to ESM. This will facilitate breaking the code into modules (for making the API call) and then subsequently setting up unit tests.
